### PR TITLE
Restore next/image optimization with Cloudflare loader (#15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,14 @@ Authentication:
 - `Authorization: Bearer <ADMIN_API_TOKEN>`
 - `x-admin-token: <ADMIN_API_TOKEN>`
 
+### 3.10 Image Optimization on Cloudflare
+
+`next/image` uses a custom loader (`src/lib/cloudflare-image-loader.ts`) and routes optimized requests via:
+
+- `/cdn-cgi/image/<options>/<src>`
+
+In local development (`npm run dev`), the loader falls back to direct image URLs.
+
 ### 4. Manage Content (CLI)
 
 See [tools/README.md](tools/README.md) for details on how to register drill PDFs.

--- a/next.config.ts
+++ b/next.config.ts
@@ -5,17 +5,10 @@ if (process.env.NODE_ENV === "development") {
   initOpenNextCloudflareForDev();
 }
 
-const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || "https://fruits-drill.stdy.workers.dev";
-const baseHostname = new URL(baseUrl).hostname;
-
 const nextConfig: NextConfig = {
   images: {
-    remotePatterns: [
-      {
-        protocol: "https",
-        hostname: baseHostname,
-      },
-    ],
+    loader: "custom",
+    loaderFile: "./src/lib/cloudflare-image-loader.ts",
   },
 };
 

--- a/src/features/drills/components/DrillCard.tsx
+++ b/src/features/drills/components/DrillCard.tsx
@@ -30,7 +30,6 @@ export const DrillCard = memo(({ drill, priority = false, queryParams = "" }: Pr
           src={drill.thumbnail.url}
           alt={drill.title}
           fill
-          unoptimized
           priority={priority}
           className="object-cover object-left-top transition-transform duration-500 scale-100 group-hover:scale-110"
           sizes="(min-width: 1024px) 25vw, (min-width: 768px) 33vw, (min-width: 640px) 50vw, 100vw"

--- a/src/features/drills/components/DrillDetail.tsx
+++ b/src/features/drills/components/DrillDetail.tsx
@@ -27,7 +27,6 @@ export const DrillDetail = ({
             src={drill.thumbnail.url}
             alt={drill.title}
             fill
-            unoptimized
             priority
             className="object-contain p-4"
             sizes="(min-width: 1024px) 50vw, 100vw"

--- a/src/lib/cloudflare-image-loader.ts
+++ b/src/lib/cloudflare-image-loader.ts
@@ -1,0 +1,20 @@
+"use client";
+
+import type { ImageLoaderProps } from "next/image";
+
+function normalizeSrc(src: string): string {
+  return src.startsWith("/") ? src.slice(1) : src;
+}
+
+export default function cloudflareImageLoader({ src, width, quality }: ImageLoaderProps): string {
+  const params = [`width=${width}`];
+  if (quality) {
+    params.push(`quality=${quality}`);
+  }
+
+  if (process.env.NODE_ENV === "development") {
+    return `${src}?${params.join("&")}`;
+  }
+
+  return `/cdn-cgi/image/${params.join(",")}/${normalizeSrc(src)}`;
+}


### PR DESCRIPTION
## Summary
- `next/image` を Cloudflare Transformations 経由で最適化する custom loader を導入
- 暫定対応だった `unoptimized` を drill サムネイル表示から除去
- README に Cloudflare画像最適化経路の説明を追加

## Changes
- `next.config.ts`
  - `images.loader = "custom"`
  - `images.loaderFile = "./src/lib/cloudflare-image-loader.ts"`
- `src/lib/cloudflare-image-loader.ts` を追加
  - 本番: `/cdn-cgi/image/<options>/<src>` を返す
  - 開発: 直接URLフォールバック
- `src/features/drills/components/DrillCard.tsx`
  - `unoptimized` を削除
- `src/features/drills/components/DrillDetail.tsx`
  - `unoptimized` を削除
- `README.md`
  - Cloudflare 画像最適化の説明を追加

## Validation
- `npm run format:check` ✅
- `npm run lint` ✅（warning のみ / error 0）
- `npm test` ✅

Closes #15
